### PR TITLE
linux-ampere-lts/ava: Align SRCREV_meta with linux-yocto recipe

### DIFF
--- a/recipes-kernel/linux/linux-ampere-lts_5.15.bb
+++ b/recipes-kernel/linux/linux-ampere-lts_5.15.bb
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 SRCREV ?= "389fd561f4a87395bc21a48f8acdf8668ed26f0b"
-SRCREV_meta ?= "63e25b5717751b4b33685bd5991d10c52934a4c6"
+SRCREV_meta ?= "f7f709bf874f85baff9f2fb0ac0341c08399b144"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 


### PR DESCRIPTION
Signed-off-by: Diego Sueiro <diego.sueiro@arm.com>
Change-Id: I3f89ff8d1035cbf95f54c73b106a56b6379a0c12