### PR TITLE
xen: Fix Dom0 earlycon kernel command line parameter

### DIFF
--- a/dynamic-layers/meta-virtualization/recipes-extended/xen/files/xen.cfg.in
+++ b/dynamic-layers/meta-virtualization/recipes-extended/xen/files/xen.cfg.in
@@ -5,4 +5,4 @@ default=xen
 
 [xen]
 options=noreboot dom0_mem=${DOM0_MEMORY_SIZE} bootscrub=0 iommu=on loglvl=error guest_loglvl=error
-kernel=Image console=hvc0 earlycon=pl011,0x100002600000 rootwait root=PARTUUID=6a60524d-061d-454a-bfd1-38989910eccd
+kernel=Image console=hvc0 earlycon=xenboot rootwait root=PARTUUID=6a60524d-061d-454a-bfd1-38989910eccd


### PR DESCRIPTION
When booting as Dom0 the earlycon needs to be set to xenboot otherwise early messages are not printed into the console.

Signed-off-by: Diego Sueiro <diego.sueiro@arm.com>
Change-Id: I847678604d9fbe09847ca7d0d728cae1a5ced04b