### PR TITLE
conf/layer.conf: Make the layer compatible with mickledore

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,7 +13,7 @@ BBFILE_COLLECTIONS += "meta-adlink-ampere"
 BBFILE_PATTERN_meta-adlink-ampere= "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-adlink-ampere = "5"
 
-LAYERSERIES_COMPAT_meta-adlink-ampere = " honister kirkstone langdale"
+LAYERSERIES_COMPAT_meta-adlink-ampere = " honister kirkstone langdale mickledore"
 
 ADLINK_AMPERE_LAYERDIR := "${LAYERDIR}"
 


### PR DESCRIPTION
This PR is to make the meta-adlink-ampere compatible with the latest Yocto release, i.e. mickledore.